### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]


### PR DESCRIPTION
Potential fix for [https://github.com/sagaraggarwal86/Configurable_Aggregate_Report/security/code-scanning/1](https://github.com/sagaraggarwal86/Configurable_Aggregate_Report/security/code-scanning/1)

In general, the fix is to explicitly declare a minimal `permissions` block for the workflow or this specific job, instead of relying on repository/organization defaults. For a simple build-and-test workflow that only checks out code and uploads artifacts, `contents: read` is sufficient; no write permissions or other scopes (issues, pull-requests, actions, etc.) are required.

The best fix without changing existing functionality is to add a `permissions` block at the job level under `build:` (line 10), applying only to this job. We will insert:

```yaml
permissions:
  contents: read
```

between `build:` and `strategy:`. This constrains the `GITHUB_TOKEN` for this job to read-only access to repository contents, which is compatible with `actions/checkout` and has no impact on the Maven build or artifact upload. No imports, methods, or other definitions are needed, as this is purely a YAML configuration change within `.github/workflows/build.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
